### PR TITLE
change cbor tag value to 42, add multibase prefix to cids in links

### DIFF
--- a/node_test.go
+++ b/node_test.go
@@ -6,8 +6,8 @@ import (
 	"sort"
 	"testing"
 
-	u "gx/ipfs/Qmb912gdngC1UWwTkhuW8knyRbcWeu5kqkxBpveLmW8bSr/go-ipfs-util"
-	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
+	cid "github.com/ipfs/go-cid"
+	u "github.com/ipfs/go-ipfs-util"
 )
 
 type testObject struct {


### PR DESCRIPTION
This should be the 'correct' implementation of the cbor ipld spec.