### PR TITLE
Integrate with the new go-ipld-format decoder framework

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.2.2: QmNrbCt8j9DT5W9Pmjy2SdudT9k8GpaDr4sRuFix3BXhgR
+1.2.3: QmeYUiuN29RaXEK79Arqe9iBaek6xExz4iikREQq9bWNGM

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   "license": "",
   "name": "go-ipld-cbor",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.2.2"
+  "version": "1.2.3"
 }
 

--- a/package.json
+++ b/package.json
@@ -9,15 +9,15 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "Qmb3Hm9QDFmfYuET4pu7Kyg8JV78jFa1nvZx5vnCZsK4ck",
+      "hash": "QmUBtPvHKFAX43XMsyxsYpMi3U5VwZ4jYFTo4kFhvAR33G",
       "name": "go-ipld-format",
-      "version": "0.4.6"
+      "version": "0.4.9"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmYhQaCYEcaPPjxJX7YcPcVKkQfRy6sJ7B3XmGFk82XYdQ",
+      "hash": "QmNw61A6sJoXMeP37mJRtQZdNhj5e3FdjoTN3v4FyE96Gk",
       "name": "go-cid",
-      "version": "0.7.12"
+      "version": "0.7.15"
     },
     {
       "author": "whyrusleeping",


### PR DESCRIPTION
Also, pre-compute the CID. We're probably going to need it anyways. The alternatives are:

1. Compute it every time we need it (slow).
2. Cache it when we first compute it (requires synchronization for thread safety).