### PR TITLE
allow calling Copy on non-map nodes

### DIFF
--- a/node.go
+++ b/node.go
@@ -147,7 +147,7 @@ func (n *Node) Copy() node.Node {
 	copy(tree, n.tree)
 
 	return &Node{
-		obj:   copyObj(n.obj).(map[interface{}]interface{}),
+		obj:   copyObj(n.obj),
 		links: links,
 		raw:   raw,
 		tree:  tree,

--- a/node_test.go
+++ b/node_test.go
@@ -19,6 +19,25 @@ func assertCid(c *cid.Cid, exp string) error {
 	return nil
 }
 
+func TestNonObject(t *testing.T) {
+	nd, err := WrapObject("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := assertCid(nd.Cid(), "zdpuAuvdvGBYa3apsrf63GU9RZcrf5EBwvb82pHjUTyecbvD8"); err != nil {
+		t.Fatal(err)
+	}
+
+	back, err := Decode(nd.Copy().RawData())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := assertCid(back.Cid(), "zdpuAuvdvGBYa3apsrf63GU9RZcrf5EBwvb82pHjUTyecbvD8"); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestBasicMarshal(t *testing.T) {
 	c := cid.NewCidV0(u.Hash([]byte("something")))
 


### PR DESCRIPTION
CBOR IPLD nodes don't have to be maps; they can also be bare values.