### PR TITLE
gx: update base32

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.2.8: QmeebqVZeEXBqJ2B4urQWfdhwRRPm84ajnCo8x8pfwbsPM
+1.2.9: QmSKrDrzpjRTiq4EK7puuNr5Rvr6Yu8Yon9fCZuK2obLYx

--- a/package.json
+++ b/package.json
@@ -9,15 +9,15 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6",
+      "hash": "QmRL2JDEtNzSkEjMgsUBXgmHKeJ7a4V6QoirXHrc93igo2",
       "name": "go-ipld-format",
-      "version": "0.5.0"
+      "version": "0.5.1"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS",
+      "hash": "QmetUj3ZqWMDVeFMRq7S9PdMauXCwBZuggfHqoS4MPt1Vy",
       "name": "go-cid",
-      "version": "0.7.17"
+      "version": "0.7.18"
     },
     {
       "author": "whyrusleeping",
@@ -33,9 +33,9 @@
     },
     {
       "author": "stebalien",
-      "hash": "QmVA4mafxbfH5aEvNz8fyoxC6J1xhAtw88B4GerPznSZBg",
+      "hash": "QmP5Lp2S1BzuBUWKA8Y25Ajtatqmv1f5cdzxAN4vFoebcf",
       "name": "go-block-format",
-      "version": "0.1.3"
+      "version": "0.1.4"
     },
     {
       "author": "multiformats",
@@ -49,6 +49,6 @@
   "license": "",
   "name": "go-ipld-cbor",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.2.8"
+  "version": "1.2.9"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/multiformats/go-multibase/pull/17
- https://github.com/ipfs/go-cid/pull/32
- https://github.com/libp2p/go-testutil/pull/11
- https://github.com/libp2p/go-libp2p-conn/pull/14
- https://github.com/libp2p/go-libp2p-connmgr/pull/4
- https://github.com/libp2p/go-libp2p-host/pull/7
- https://github.com/libp2p/go-libp2p-swarm/pull/31
- https://github.com/libp2p/go-libp2p-netutil/pull/10
- https://github.com/libp2p/go-libp2p-blankhost/pull/4
- https://github.com/libp2p/go-libp2p-circuit/pull/13
- https://github.com/libp2p/go-libp2p/pull/220
- https://github.com/libp2p/go-libp2p-kbucket/pull/12
- https://github.com/libp2p/go-libp2p-routing/pull/16
- https://github.com/libp2p/go-libp2p-kad-dht/pull/84
- https://github.com/libp2p/go-floodsub/pull/32
- https://github.com/ipfs/go-block-format/pull/7
- https://github.com/ipfs/go-ipld-format/pull/26


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace