### PR TITLE
test: add failing test for nested structs

### DIFF
--- a/node_test.go
+++ b/node_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math"
+	"math/big"
 	"sort"
 	"strings"
 	"testing"
@@ -534,4 +535,72 @@ func TestCanonicalStructEncoding(t *testing.T) {
 	if !bytes.Equal(expraw, m.RawData()) {
 		t.Fatal("not canonical")
 	}
+}
+
+type TestMe struct {
+	Hello *big.Int
+	World big.Int
+	Hi    int
+}
+
+func TestBigIntRoundtrip(t *testing.T) {
+	RegisterCborType(TestMe{})
+
+	one := TestMe{
+		Hello: big.NewInt(100),
+		World: *big.NewInt(99),
+	}
+
+	bytes, err := DumpObject(&one)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var oneBack TestMe
+	if err := DecodeInto(bytes, &oneBack); err != nil {
+		t.Fatal(err)
+	}
+
+	if one.Hello.Cmp(oneBack.Hello) != 0 {
+		t.Fatal("failed to roundtrip *big.Int")
+	}
+
+	if one.World.Cmp(&oneBack.World) != 0 {
+		t.Fatal("failed to roundtrip big.Int")
+	}
+
+	list := map[string]*TestMe{
+		"hello": &TestMe{Hello: big.NewInt(10), World: *big.NewInt(101), Hi: 1},
+		"world": &TestMe{Hello: big.NewInt(9), World: *big.NewInt(901), Hi: 3},
+	}
+
+	bytes, err = DumpObject(list)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var listBack map[string]*TestMe
+	if err := DecodeInto(bytes, &listBack); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log(listBack["hello"])
+	t.Log(listBack["world"])
+
+	if list["hello"].Hello.Cmp(listBack["hello"].Hello) != 0 {
+		t.Fatalf("failed to roundtrip *big.Int: %s != %s", list["hello"].Hello, listBack["hello"].Hello)
+	}
+
+	if list["hello"].World.Cmp(&listBack["hello"].World) != 0 {
+		t.Fatalf("failed to roundtrip big.Int: %s != %s", &list["hello"].World, &listBack["hello"].World)
+	}
+
+	if list["world"].Hello.Cmp(listBack["world"].Hello) != 0 {
+		t.Fatalf("failed to roundtrip *big.Int: %s != %s", list["world"].Hello, listBack["world"].Hello)
+	}
+
+	if list["world"].World.Cmp(&listBack["world"].World) != 0 {
+		t.Fatalf("failed to roundtrip big.Int: %s != %s", &list["world"].World, &listBack["world"].World)
+	}
+
 }

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     },
     {
       "author": "why",
-      "hash": "QmSaDQWMxJBMtzQWnGoDppbwSEbHv4aJcD86CMSdszPU4L",
+      "hash": "QmcrriCMhjb5ZWzmPNxmP53px47tSPcXBNaMtLdgcKFJYk",
       "name": "refmt",
-      "version": "1.0.0"
+      "version": "1.1.0"
     }
   ],
   "gxVersion": "0.10.0",


### PR DESCRIPTION
I ran into this problem it seems to originate in refmt: https://github.com/polydawn/refmt/issues/22

```
go test -run TestBigIntRoundtrip\$ .
--- FAIL: TestBigIntRoundtrip (0.00s)
	node_test.go:587: &{9 {false [901]} 3}
	node_test.go:588: &{9 {false [901]} 3}
	node_test.go:591: failed to roundtrip *big.Int: 10 != 9
FAIL
FAIL	github.com/ipfs/go-ipld-cbor	0.009s
```