### PR TITLE
add link names to the links returned from node.Links()

### DIFF
--- a/node.go
+++ b/node.go
@@ -310,7 +310,7 @@ func compLinks(obj interface{}) ([]*node.Link, error) {
 	var out []*node.Link
 	err := traverse(obj, "", func(name string, val interface{}) error {
 		if lnk, ok := val.(*cid.Cid); ok {
-			out = append(out, &node.Link{Cid: lnk})
+			out = append(out, &node.Link{Name: name, Cid: lnk})
 		}
 		return nil
 	})

--- a/node_test.go
+++ b/node_test.go
@@ -142,6 +142,10 @@ func TestMarshalRoundtrip(t *testing.T) {
 		t.Fatal("didnt have enough links")
 	}
 
+	if nd1.Links()[0].Name != "/cats/qux" {
+		t.Fatalf("incorrect name %s", nd1.Links()[0].Name )
+	}
+
 	nd2, err := Decode(nd1.RawData(), mh.SHA2_256, -1)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
I'm in a situation where I need to update all the links on an object. I noticed that links *have* names defined in the struct, but don't have names when put into the links slice.

This adds the name.