### PR TITLE
share a pool of (un)marshallers

### DIFF
--- a/encoding/cloner.go
+++ b/encoding/cloner.go
@@ -1,0 +1,29 @@
+package encoding
+
+import (
+	refmt "github.com/polydawn/refmt"
+	"github.com/polydawn/refmt/obj/atlas"
+)
+
+// PooledCloner is a thread-safe pooled object cloner.
+type PooledCloner struct {
+	Count   int
+	cloners chan refmt.Cloner
+}
+
+// SetAtlas set sets the pool's atlas. It is *not* safe to call this
+// concurrently.
+func (p *PooledCloner) SetAtlas(atlas atlas.Atlas) {
+	p.cloners = make(chan refmt.Cloner, p.Count)
+	for len(p.cloners) < cap(p.cloners) {
+		p.cloners <- refmt.NewCloner(atlas)
+	}
+}
+
+// Clone clones a into b using a cloner from the pool.
+func (p *PooledCloner) Clone(a, b interface{}) error {
+	c := <-p.cloners
+	err := c.Clone(a, b)
+	p.cloners <- c
+	return err
+}

--- a/encoding/cloner.go
+++ b/encoding/cloner.go
@@ -12,12 +12,14 @@ type PooledCloner struct {
 	pool sync.Pool
 }
 
-// SetAtlas set sets the pool's atlas. It is *not* safe to call this
-// concurrently.
-func (p *PooledCloner) SetAtlas(atl atlas.Atlas) {
-	p.pool = sync.Pool{
-		New: func() interface{} {
-			return refmt.NewCloner(atl)
+// NewPooledCloner returns a PooledCloner with the given atlas. Do not copy
+// after use.
+func NewPooledCloner(atl atlas.Atlas) PooledCloner {
+	return PooledCloner{
+		pool: sync.Pool{
+			New: func() interface{} {
+				return refmt.NewCloner(atl)
+			},
 		},
 	}
 }

--- a/encoding/cloner.go
+++ b/encoding/cloner.go
@@ -1,29 +1,31 @@
 package encoding
 
 import (
+	"sync"
+
 	refmt "github.com/polydawn/refmt"
 	"github.com/polydawn/refmt/obj/atlas"
 )
 
 // PooledCloner is a thread-safe pooled object cloner.
 type PooledCloner struct {
-	Count   int
-	cloners chan refmt.Cloner
+	pool sync.Pool
 }
 
 // SetAtlas set sets the pool's atlas. It is *not* safe to call this
 // concurrently.
-func (p *PooledCloner) SetAtlas(atlas atlas.Atlas) {
-	p.cloners = make(chan refmt.Cloner, p.Count)
-	for len(p.cloners) < cap(p.cloners) {
-		p.cloners <- refmt.NewCloner(atlas)
+func (p *PooledCloner) SetAtlas(atl atlas.Atlas) {
+	p.pool = sync.Pool{
+		New: func() interface{} {
+			return refmt.NewCloner(atl)
+		},
 	}
 }
 
 // Clone clones a into b using a cloner from the pool.
 func (p *PooledCloner) Clone(a, b interface{}) error {
-	c := <-p.cloners
+	c := p.pool.Get().(refmt.Cloner)
 	err := c.Clone(a, b)
-	p.cloners <- c
+	p.pool.Put(c)
 	return err
 }

--- a/encoding/marshaller.go
+++ b/encoding/marshaller.go
@@ -1,0 +1,79 @@
+package encoding
+
+import (
+	"bytes"
+	"io"
+
+	cbor "github.com/polydawn/refmt/cbor"
+	"github.com/polydawn/refmt/obj/atlas"
+)
+
+type proxyWriter struct {
+	w io.Writer
+}
+
+func (w *proxyWriter) Write(b []byte) (int, error) {
+	return w.w.Write(b)
+}
+
+// Marshaller is a reusbale CBOR marshaller.
+type Marshaller struct {
+	marshal *cbor.Marshaller
+	writer  proxyWriter
+}
+
+// NewMarshallerAtlased constructs a new cbor Marshaller using the given atlas.
+func NewMarshallerAtlased(atl atlas.Atlas) *Marshaller {
+	m := new(Marshaller)
+	m.marshal = cbor.NewMarshallerAtlased(&m.writer, atl)
+	return m
+}
+
+// Encode encodes the given object to the given writer.
+func (m *Marshaller) Encode(obj interface{}, w io.Writer) error {
+	m.writer.w = w
+	err := m.marshal.Marshal(obj)
+	m.writer.w = nil
+	return err
+}
+
+// Marshal marshels the given object to a byte slice.
+func (m *Marshaller) Marshal(obj interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := m.Encode(obj, &buf); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// PooledMarshaller is a thread-safe pooled CBOR marshaller.
+type PooledMarshaller struct {
+	Count       int
+	marshallers chan *Marshaller
+}
+
+// SetAtlas set sets the pool's atlas. It is *not* safe to call this
+// concurrently.
+func (p *PooledMarshaller) SetAtlas(atlas atlas.Atlas) {
+	p.marshallers = make(chan *Marshaller, p.Count)
+	for len(p.marshallers) < cap(p.marshallers) {
+		p.marshallers <- NewMarshallerAtlased(atlas)
+	}
+}
+
+// Marshal marshals the passed object using the pool of marshallers.
+func (p *PooledMarshaller) Marshal(obj interface{}) ([]byte, error) {
+	m := <-p.marshallers
+	bts, err := m.Marshal(obj)
+	p.marshallers <- m
+	return bts, err
+}
+
+// Encode encodes the passed object to the given writer using the pool of
+// marshallers.
+func (p *PooledMarshaller) Encode(obj interface{}, w io.Writer) error {
+	m := <-p.marshallers
+	err := m.Encode(obj, w)
+	p.marshallers <- m
+	return err
+}

--- a/encoding/marshaller.go
+++ b/encoding/marshaller.go
@@ -52,12 +52,14 @@ type PooledMarshaller struct {
 	pool sync.Pool
 }
 
-// SetAtlas set sets the pool's atlas. It is *not* safe to call this
-// concurrently.
-func (p *PooledMarshaller) SetAtlas(atl atlas.Atlas) {
-	p.pool = sync.Pool{
-		New: func() interface{} {
-			return NewMarshallerAtlased(atl)
+// NewPooledMarshaller returns a PooledMarshaller with the given atlas. Do not
+// copy after use.
+func NewPooledMarshaller(atl atlas.Atlas) PooledMarshaller {
+	return PooledMarshaller{
+		pool: sync.Pool{
+			New: func() interface{} {
+				return NewMarshallerAtlased(atl)
+			},
 		},
 	}
 }

--- a/encoding/unmarshaller.go
+++ b/encoding/unmarshaller.go
@@ -49,12 +49,14 @@ type PooledUnmarshaller struct {
 	pool sync.Pool
 }
 
-// SetAtlas set sets the pool's atlas. It is *not* safe to call this
-// concurrently.
-func (p *PooledUnmarshaller) SetAtlas(atl atlas.Atlas) {
-	p.pool = sync.Pool{
-		New: func() interface{} {
-			return NewUnmarshallerAtlased(atl)
+// NewPooledUnmarshaller returns a PooledUnmarshaller with the given atlas. Do
+// not copy after use.
+func NewPooledUnmarshaller(atl atlas.Atlas) PooledUnmarshaller {
+	return PooledUnmarshaller{
+		pool: sync.Pool{
+			New: func() interface{} {
+				return NewUnmarshallerAtlased(atl)
+			},
 		},
 	}
 }

--- a/encoding/unmarshaller.go
+++ b/encoding/unmarshaller.go
@@ -1,0 +1,76 @@
+package encoding
+
+import (
+	"bytes"
+	"io"
+
+	cbor "github.com/polydawn/refmt/cbor"
+	"github.com/polydawn/refmt/obj/atlas"
+)
+
+type proxyReader struct {
+	r io.Reader
+}
+
+func (r *proxyReader) Read(b []byte) (int, error) {
+	return r.r.Read(b)
+}
+
+// Unmarshaller is a reusable CBOR unmarshaller.
+type Unmarshaller struct {
+	unmarshal *cbor.Unmarshaller
+	reader    proxyReader
+}
+
+// NewUnmarshallerAtlased creates a new reusable unmarshaller.
+func NewUnmarshallerAtlased(atl atlas.Atlas) *Unmarshaller {
+	m := new(Unmarshaller)
+	m.unmarshal = cbor.NewUnmarshallerAtlased(&m.reader, atl)
+	return m
+}
+
+// Decode reads a CBOR object from the given reader and decodes it into the
+// given object.
+func (m *Unmarshaller) Decode(r io.Reader, obj interface{}) error {
+	m.reader.r = r
+	err := m.unmarshal.Unmarshal(obj)
+	m.reader.r = nil
+	return err
+}
+
+// Unmarshal unmarshals the given CBOR byte slice into the given object.
+func (m *Unmarshaller) Unmarshal(b []byte, obj interface{}) error {
+	return m.Decode(bytes.NewReader(b), obj)
+}
+
+// PooledUnmarshaller is a thread-safe pooled CBOR unmarshaller.
+type PooledUnmarshaller struct {
+	Count         int
+	unmarshallers chan *Unmarshaller
+}
+
+// SetAtlas set sets the pool's atlas. It is *not* safe to call this
+// concurrently.
+func (p *PooledUnmarshaller) SetAtlas(atlas atlas.Atlas) {
+	p.unmarshallers = make(chan *Unmarshaller, p.Count)
+	for len(p.unmarshallers) < cap(p.unmarshallers) {
+		p.unmarshallers <- NewUnmarshallerAtlased(atlas)
+	}
+}
+
+// Decode decodes an object from the passed reader into the given object using
+// the pool of unmarshallers.
+func (p *PooledUnmarshaller) Decode(r io.Reader, obj interface{}) error {
+	u := <-p.unmarshallers
+	err := u.Decode(r, obj)
+	p.unmarshallers <- u
+	return err
+}
+
+// Unmarshal unmarshals the passed object using the pool of unmarshallers.
+func (p *PooledUnmarshaller) Unmarshal(b []byte, obj interface{}) error {
+	u := <-p.unmarshallers
+	err := u.Unmarshal(b, obj)
+	p.unmarshallers <- u
+	return err
+}

--- a/refmt.go
+++ b/refmt.go
@@ -51,9 +51,9 @@ func rebuildAtlas() {
 	cborAtlas = atlas.MustBuild(atlasEntries...).
 		WithMapMorphism(atlas.MapMorphism{atlas.KeySortMode_RFC7049})
 
-	marshaller.SetAtlas(cborAtlas)
-	unmarshaller.SetAtlas(cborAtlas)
-	cloner.SetAtlas(cborAtlas)
+	marshaller = encoding.NewPooledMarshaller(cborAtlas)
+	unmarshaller = encoding.NewPooledUnmarshaller(cborAtlas)
+	cloner = encoding.NewPooledCloner(cborAtlas)
 }
 
 // RegisterCborType allows to register a custom cbor type

--- a/refmt.go
+++ b/refmt.go
@@ -2,7 +2,6 @@ package cbornode
 
 import (
 	"math/big"
-	"runtime"
 
 	cid "github.com/ipfs/go-cid"
 
@@ -39,10 +38,9 @@ var cborSortingMode = atlas.KeySortMode_RFC7049
 var atlasEntries = []*atlas.AtlasEntry{cidAtlasEntry, bigIntAtlasEntry}
 
 var (
-	numWorkers   = runtime.NumCPU() + 1
-	cloner       = encoding.PooledCloner{Count: numWorkers}
-	unmarshaller = encoding.PooledUnmarshaller{Count: numWorkers}
-	marshaller   = encoding.PooledMarshaller{Count: numWorkers}
+	cloner       encoding.PooledCloner
+	unmarshaller encoding.PooledUnmarshaller
+	marshaller   encoding.PooledMarshaller
 )
 
 func init() {

--- a/refmt.go
+++ b/refmt.go
@@ -39,7 +39,7 @@ var cborSortingMode = atlas.KeySortMode_RFC7049
 var atlasEntries = []*atlas.AtlasEntry{cidAtlasEntry, bigIntAtlasEntry}
 
 var (
-	numWorkers   = runtime.NumCPU() * 2
+	numWorkers   = runtime.NumCPU() + 1
 	cloner       = encoding.PooledCloner{Count: numWorkers}
 	unmarshaller = encoding.PooledUnmarshaller{Count: numWorkers}
 	marshaller   = encoding.PooledMarshaller{Count: numWorkers}

--- a/refmt.go
+++ b/refmt.go
@@ -1,0 +1,71 @@
+package cbornode
+
+import (
+	"math/big"
+	"runtime"
+
+	cid "github.com/ipfs/go-cid"
+
+	encoding "github.com/ipfs/go-ipld-cbor/encoding"
+
+	"github.com/polydawn/refmt/obj/atlas"
+)
+
+// This atlas describes the CBOR Tag (42) for IPLD links, such that refmt can marshal and unmarshal them
+var cidAtlasEntry = atlas.BuildEntry(cid.Cid{}).
+	UseTag(CBORTagLink).
+	Transform().
+	TransformMarshal(atlas.MakeMarshalTransformFunc(
+		castCidToBytes,
+	)).
+	TransformUnmarshal(atlas.MakeUnmarshalTransformFunc(
+		castBytesToCid,
+	)).
+	Complete()
+
+var bigIntAtlasEntry = atlas.BuildEntry(big.Int{}).Transform().
+	TransformMarshal(atlas.MakeMarshalTransformFunc(
+		func(i big.Int) ([]byte, error) {
+			return i.Bytes(), nil
+		})).
+	TransformUnmarshal(atlas.MakeUnmarshalTransformFunc(
+		func(x []byte) (big.Int, error) {
+			return *big.NewInt(0).SetBytes(x), nil
+		})).
+	Complete()
+
+var cborAtlas atlas.Atlas
+var cborSortingMode = atlas.KeySortMode_RFC7049
+var atlasEntries = []*atlas.AtlasEntry{cidAtlasEntry, bigIntAtlasEntry}
+
+var (
+	numWorkers   = runtime.NumCPU() * 2
+	cloner       = encoding.PooledCloner{Count: numWorkers}
+	unmarshaller = encoding.PooledUnmarshaller{Count: numWorkers}
+	marshaller   = encoding.PooledMarshaller{Count: numWorkers}
+)
+
+func init() {
+	rebuildAtlas()
+}
+
+func rebuildAtlas() {
+	cborAtlas = atlas.MustBuild(atlasEntries...).
+		WithMapMorphism(atlas.MapMorphism{atlas.KeySortMode_RFC7049})
+
+	marshaller.SetAtlas(cborAtlas)
+	unmarshaller.SetAtlas(cborAtlas)
+	cloner.SetAtlas(cborAtlas)
+}
+
+// RegisterCborType allows to register a custom cbor type
+func RegisterCborType(i interface{}) {
+	var entry *atlas.AtlasEntry
+	if ae, ok := i.(*atlas.AtlasEntry); ok {
+		entry = ae
+	} else {
+		entry = atlas.BuildEntry(i).StructMap().AutogenerateWithSortingScheme(atlas.KeySortMode_RFC7049).Complete()
+	}
+	atlasEntries = append(atlasEntries, entry)
+	rebuildAtlas()
+}

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -1,0 +1,60 @@
+package cbornode
+
+import (
+	"testing"
+
+	mh "github.com/multiformats/go-multihash"
+)
+
+type myStruct struct {
+	items map[string]myStruct
+	foo   string
+	bar   []byte
+	baz   []int
+}
+
+func init() {
+	RegisterCborType(myStruct{})
+}
+
+func testStruct() myStruct {
+	return myStruct{
+		items: map[string]myStruct{
+			"foo": {
+				foo: "foo",
+				bar: []byte("bar"),
+				baz: []int{1, 2, 3, 4},
+			},
+			"bar": {
+				bar: []byte("bar"),
+				baz: []int{1, 2, 3, 4},
+			},
+		},
+		baz: []int{5, 1, 2},
+	}
+}
+
+func BenchmarkWrapObject(b *testing.B) {
+	obj := testStruct()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		nd, err := WrapObject(obj, mh.SHA2_256, -1)
+		if err != nil {
+			b.Fatal(err, nd)
+		}
+	}
+}
+func BenchmarkDecodeBlock(b *testing.B) {
+	obj := testStruct()
+	nd, err := WrapObject(obj, mh.SHA2_256, -1)
+	if err != nil {
+		b.Fatal(err, nd)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		nd2, err := DecodeBlock(nd)
+		if err != nil {
+			b.Fatal(err, nd2)
+		}
+	}
+}

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -7,31 +7,31 @@ import (
 	mh "github.com/multiformats/go-multihash"
 )
 
-type myStruct struct {
-	items map[string]myStruct
-	foo   string
-	bar   []byte
-	baz   []int
+type MyStruct struct {
+	Items map[string]MyStruct
+	Foo   string
+	Bar   []byte
+	Baz   []int
 }
 
 func init() {
-	RegisterCborType(myStruct{})
+	RegisterCborType(MyStruct{})
 }
 
-func testStruct() myStruct {
-	return myStruct{
-		items: map[string]myStruct{
-			"foo": {
-				foo: "foo",
-				bar: []byte("bar"),
-				baz: []int{1, 2, 3, 4},
+func testStruct() MyStruct {
+	return MyStruct{
+		Items: map[string]MyStruct{
+			"Foo": {
+				Foo: "Foo",
+				Bar: []byte("Bar"),
+				Baz: []int{1, 2, 3, 4},
 			},
-			"bar": {
-				bar: []byte("bar"),
-				baz: []int{1, 2, 3, 4},
+			"Bar": {
+				Bar: []byte("Bar"),
+				Baz: []int{1, 2, 3, 4},
 			},
 		},
-		baz: []int{5, 1, 2},
+		Baz: []int{5, 1, 2},
 	}
 }
 
@@ -101,4 +101,14 @@ func BenchmarkDecodeBlockParallel(b *testing.B) {
 		}()
 	}
 	wg.Wait()
+}
+
+func BenchmarkDumpObject(b *testing.B) {
+	obj := testStruct()
+	for i := 0; i < b.N; i++ {
+		bytes, err := DumpObject(obj)
+		if err != nil {
+			b.Fatal(err, bytes)
+		}
+	}
 }


### PR DESCRIPTION
Also, use a cloner instead of unmarshalling when wrapping an object.

This gives about a 2.5x speedup in my simple benchmark and probably saves the GC a lot of trouble.