### PR TITLE
cbor: decode undefined as null

### DIFF
--- a/encoding/unmarshaller.go
+++ b/encoding/unmarshaller.go
@@ -26,7 +26,7 @@ type Unmarshaller struct {
 // NewUnmarshallerAtlased creates a new reusable unmarshaller.
 func NewUnmarshallerAtlased(atl atlas.Atlas) *Unmarshaller {
 	m := new(Unmarshaller)
-	m.unmarshal = cbor.NewUnmarshallerAtlased(&m.reader, atl)
+	m.unmarshal = cbor.NewUnmarshallerAtlased(cbor.DecodeOptions{CoerceUndefToNull: true}, &m.reader, atl)
 	return m
 }
 

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     },
     {
       "author": "why",
-      "hash": "QmfWqohMtbivn5NRJvtrLzCW3EU4QmoLvVNtmvo9vbdtVA",
+      "hash": "QmNScbpMAm3r2D25kmfQ43JCbQ8QCtai4V4DNz5ebuXUuZ",
       "name": "refmt",
-      "version": "1.1.2"
+      "version": "1.1.3"
     }
   ],
   "gxVersion": "0.10.0",


### PR DESCRIPTION
See: https://github.com/ipfs/go-ipfs/issues/5776

This won't round-trip undef, it'll just convert it to null (which is what most decoders do anyways).

also fixes #53