### PR TITLE
fastpath CBOR

### DIFF
--- a/encoding/cloner.go
+++ b/encoding/cloner.go
@@ -24,8 +24,16 @@ func NewPooledCloner(atl atlas.Atlas) PooledCloner {
 	}
 }
 
+type selfCloner interface {
+	Clone(b interface{}) error
+}
+
 // Clone clones a into b using a cloner from the pool.
 func (p *PooledCloner) Clone(a, b interface{}) error {
+	if self, ok := a.(selfCloner); ok {
+		return self.Clone(b)
+	}
+
 	c := p.pool.Get().(refmt.Cloner)
 	err := c.Clone(a, b)
 	p.pool.Put(c)

--- a/encoding/marshaller.go
+++ b/encoding/marshaller.go
@@ -30,10 +30,20 @@ func NewMarshallerAtlased(atl atlas.Atlas) *Marshaller {
 	return m
 }
 
+type cborMarshaler interface {
+	MarshalCBOR(w io.Writer) error
+}
+
 // Encode encodes the given object to the given writer.
 func (m *Marshaller) Encode(obj interface{}, w io.Writer) error {
 	m.writer.w = w
-	err := m.marshal.Marshal(obj)
+	var err error
+	selfMarshaling, ok := obj.(cborMarshaler)
+	if ok {
+		err = selfMarshaling.MarshalCBOR(w)
+	} else {
+		err = m.marshal.Marshal(obj)
+	}
 	m.writer.w = nil
 	return err
 }

--- a/encoding/unmarshaller.go
+++ b/encoding/unmarshaller.go
@@ -30,11 +30,20 @@ func NewUnmarshallerAtlased(atl atlas.Atlas) *Unmarshaller {
 	return m
 }
 
+type cborUnmarshaler interface {
+	UnmarshalCBOR(r io.Reader) error
+}
+
 // Decode reads a CBOR object from the given reader and decodes it into the
 // given object.
-func (m *Unmarshaller) Decode(r io.Reader, obj interface{}) error {
+func (m *Unmarshaller) Decode(r io.Reader, obj interface{}) (err error) {
 	m.reader.r = r
-	err := m.unmarshal.Unmarshal(obj)
+	selfUnmarshaler, ok := obj.(cborUnmarshaler)
+	if ok {
+		err = selfUnmarshaler.UnmarshalCBOR(r)
+	} else {
+		err = m.unmarshal.Unmarshal(obj)
+	}
 	m.reader.r = nil
 	return err
 }


### PR DESCRIPTION
I realize this *might* not be mergable as is... because it changes how Tree() and Links() are handled and doesn't error in the same place as before.

I was looking at this PR: https://github.com/ipfs/go-hamt-ipld/pull/29/files and looking at some benchmarks noticed that refmt was still taking up a bunch of time in our blockservice interface and I realized that's because when the block comes back it is still decoded into an interface{}. 

This PR allows lazy loading of Tree and Links (which are often unused) and allows fast-path cbor if objects support them.