### PR TITLE
fix: store: expCid vs actualCid guard

### DIFF
--- a/store.go
+++ b/store.go
@@ -103,7 +103,7 @@ func (s *BasicIpldStore) Put(ctx context.Context, v interface{}) (cid.Cid, error
 
 	var expCid cid.Cid
 	if c, ok := v.(cidProvider); ok {
-		expCid := c.Cid()
+		expCid = c.Cid()
 		pref := expCid.Prefix()
 		mhType = pref.MhType
 		mhLen = pref.MhLength
@@ -133,13 +133,13 @@ func (s *BasicIpldStore) Put(ctx context.Context, v interface{}) (cid.Cid, error
 			return cid.Undef, err
 		}
 
-		if err := s.Blocks.Put(ctx, blk); err != nil {
-			return cid.Undef, err
-		}
-
 		blkCid := blk.Cid()
 		if expCid != cid.Undef && blkCid != expCid {
 			return cid.Undef, fmt.Errorf("your object is not being serialized the way it expects to")
+		}
+
+		if err := s.Blocks.Put(ctx, blk); err != nil {
+			return cid.Undef, err
 		}
 
 		return blkCid, nil
@@ -150,13 +150,13 @@ func (s *BasicIpldStore) Put(ctx context.Context, v interface{}) (cid.Cid, error
 		return cid.Undef, err
 	}
 
-	if err := s.Blocks.Put(ctx, nd); err != nil {
-		return cid.Undef, err
-	}
-
 	ndCid := nd.Cid()
 	if expCid != cid.Undef && ndCid != expCid {
 		return cid.Undef, fmt.Errorf("your object is not being serialized the way it expects to")
+	}
+
+	if err := s.Blocks.Put(ctx, nd); err != nil {
+		return cid.Undef, err
 	}
 
 	return ndCid, nil


### PR DESCRIPTION
In the `BasicIpldStore.Put()` method we have guards that check if the object's provided CID equals the one derived internally. [Here](https://github.com/ipfs/go-ipld-cbor/blob/master/store.go#L141) and [here](https://github.com/ipfs/go-ipld-cbor/blob/master/store.go#L158).

One problem is that these guards first include a check to see if `expCid != cid.Undef` and this will never be the case because `expCid` is only [assigned locally in this `if` block](https://github.com/ipfs/go-ipld-cbor/blob/master/store.go#L106)- no assignment to `expCid` escapes or occurs outside that block so it will always equal `cid.Undef` in these guards. 

The other behavioral problem with these guards, I think, is that they are placed _after_ the IPLD block has already been written to the underlying blockstore. So the IPLD block could be written to the blockstore with a CID that the caller does not have. If this is the correct positioning of the guards because the IPLD block should be written with the derived CID even if it does not match the provided one, in that case I think it would make sense for the method to return the CID it wrote to the blockstore with instead of returning [cid.Undef](https://github.com/ipfs/go-ipld-cbor/blob/master/store.go#L159). 