### PR TITLE
deprecate DumpObject() in favor of better named Encode()

### DIFF
--- a/node.go
+++ b/node.go
@@ -396,8 +396,13 @@ func (n *Node) MarshalJSON() ([]byte, error) {
 }
 
 // DumpObject marshals any object into its CBOR serialized byte representation
-// TODO: rename
+// Deprecated: use Encode instead.
 func DumpObject(obj interface{}) (out []byte, err error) {
+	return Encode(obj)
+}
+
+// Encode marshals any object into its CBOR serialized byte representation
+func Encode(obj interface{}) (out []byte, err error) {
 	return marshaller.Marshal(obj)
 }
 

--- a/node_test.go
+++ b/node_test.go
@@ -593,7 +593,7 @@ func TestBigIntRoundtrip(t *testing.T) {
 		World: *big.NewInt(99),
 	}
 
-	bytes, err := DumpObject(&one)
+	bytes, err := Encode(&one)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -616,7 +616,7 @@ func TestBigIntRoundtrip(t *testing.T) {
 		"world": {Hello: big.NewInt(9), World: *big.NewInt(901), Hi: 3},
 	}
 
-	bytes, err = DumpObject(list)
+	bytes, err = Encode(list)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -111,10 +111,10 @@ func BenchmarkDecodeBlockParallel(b *testing.B) {
 	}
 }
 
-func BenchmarkDumpObject(b *testing.B) {
+func BenchmarkEncode(b *testing.B) {
 	obj := testStruct()
 	for i := 0; i < b.N; i++ {
-		bytes, err := DumpObject(obj)
+		bytes, err := Encode(obj)
 		if err != nil {
 			b.Fatal(err, bytes)
 		}


### PR DESCRIPTION
Following https://github.com/ipfs/go-ipld-cbor/pull/102, this PR harmonize the public API of the package, and address that long standing `TODO`.