### PR TITLE
feat: increased strictness in decoding

### DIFF
--- a/encoding/unmarshaller.go
+++ b/encoding/unmarshaller.go
@@ -9,6 +9,17 @@ import (
 	"github.com/polydawn/refmt/obj/atlas"
 )
 
+// DAGCBORDecodeOptions returns the shared refmt decode strictness used for
+// DAG-CBOR data model decoding.
+func DAGCBORDecodeOptions() cbor.DecodeOptions {
+	return cbor.DecodeOptions{
+		CoerceUndefToNull: true,
+		RejectIndefinite:  true,
+		RejectNaN:         true,
+		RejectInfinity:    true,
+	}
+}
+
 type proxyReader struct {
 	r io.Reader
 }
@@ -26,7 +37,7 @@ type Unmarshaller struct {
 // NewUnmarshallerAtlased creates a new reusable unmarshaller.
 func NewUnmarshallerAtlased(atl atlas.Atlas) *Unmarshaller {
 	m := new(Unmarshaller)
-	m.unmarshal = cbor.NewUnmarshallerAtlased(cbor.DecodeOptions{CoerceUndefToNull: true}, &m.reader, atl)
+	m.unmarshal = cbor.NewUnmarshallerAtlased(DAGCBORDecodeOptions(), &m.reader, atl)
 	return m
 }
 

--- a/node_test.go
+++ b/node_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -15,6 +16,7 @@ import (
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
+	recbor "github.com/polydawn/refmt/cbor"
 )
 
 func init() {
@@ -87,6 +89,73 @@ func TestDecodeIntoNonObject(t *testing.T) {
 	}
 	if s != "foobar" {
 		t.Fatal("strings don't match")
+	}
+}
+
+func TestDecodeIntoRejectsInvalidDAGCBOR(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    []byte
+		wantErr error
+	}{
+		{
+			name:    "indefinite list",
+			data:    []byte{0x9f, 0xff},
+			wantErr: recbor.ErrIndefiniteLength,
+		},
+		{
+			name:    "nan",
+			data:    []byte{0xfb, 0x7f, 0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			wantErr: recbor.ErrFloatNaN,
+		},
+		{
+			name:    "positive infinity",
+			data:    []byte{0xfb, 0x7f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			wantErr: recbor.ErrFloatInfinity,
+		},
+		{
+			name:    "negative infinity",
+			data:    []byte{0xfb, 0xff, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			wantErr: recbor.ErrFloatInfinity,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var v interface{}
+			if err := DecodeInto(tc.data, &v); !errors.Is(err, tc.wantErr) {
+				t.Fatalf("expected %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestDecodeIntoAllowsRelaxedCanonicalForms(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{
+			name: "non-minimal unsigned integer",
+			data: []byte{0x18, 0x17},
+		},
+		{
+			name: "non-minimal string length",
+			data: []byte{0x78, 0x01, 'a'},
+		},
+		{
+			name: "single precision float",
+			data: []byte{0xfa, 0x3f, 0x80, 0x00, 0x00},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var v interface{}
+			if err := DecodeInto(tc.data, &v); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }
 

--- a/store.go
+++ b/store.go
@@ -7,6 +7,7 @@ import (
 
 	block "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
+	cborencoding "github.com/ipfs/go-ipld-cbor/encoding"
 	mh "github.com/multiformats/go-multihash"
 	recbor "github.com/polydawn/refmt/cbor"
 	atlas "github.com/polydawn/refmt/obj/atlas"
@@ -83,7 +84,7 @@ func (s *BasicIpldStore) decode(b []byte, out interface{}) error {
 	if s.Atlas == nil {
 		return DecodeInto(b, out)
 	} else {
-		return recbor.UnmarshalAtlased(recbor.DecodeOptions{}, b, out, *s.Atlas)
+		return recbor.UnmarshalAtlased(cborencoding.DAGCBORDecodeOptions(), b, out, *s.Atlas)
 	}
 }
 


### PR DESCRIPTION
* reject indefinite length items
* reject NaN
* reject [+/-]Infinity

none of these should be present in dag-cbor data.

Similar to https://github.com/ipld/go-ipld-prime/pull/630 but not including the strict int decoding rule here to be a little more relaxed.